### PR TITLE
ECHO-413-views-pl-detect-empty-aspects-and-flag-hide-them-on-the-ui

### DIFF
--- a/services/aspect_processor.py
+++ b/services/aspect_processor.py
@@ -37,6 +37,13 @@ async def process_single_aspect(
         formated_initial_rag_prompt, segment_ids=[str(segment_id) for segment_id in segment_ids]
     )
 
+    if len(rag_prompt) < 100:
+        # Returns if nothing is found: Sorry, I'm not able to provide an answer to that question.[no-context]
+        logger.error(f"RAG prompt is too short for aspect '{tentative_aspect_topic}'")
+        raise ValueError(
+            f"RAG prompt is too short for aspect '{tentative_aspect_topic}'. \nRAG prompt: {rag_prompt}"
+        )
+
     # Prepare RAG messages
     rag_messages = [
         {"role": "system", "content": rag_system_prompt},


### PR DESCRIPTION
Add validation for RAG prompt length in process_single_aspect function. Implemented a check to ensure the RAG prompt is at least 100 characters long. If the prompt is too short, an error is logged and a ValueError is raised, improving error handling in the aspect processing workflow.